### PR TITLE
Rf caddversionsto requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ certifi==2020.11.8
 chardet==3.0.4
 html2text==2020.1.16
 idna==2.10
+lxml==4.6.2
 numpy==1.19.4
 pandas==1.1.4
 python-dateutil==2.8.1


### PR DESCRIPTION
I added versions to python requirments because, I got delayed trying to figure out the relationship between beautifulsoup and bs4. There was also an lxml parser missing in my virtualenv.
I thought it might help others avoid my faffing.

Feel free to reject if its not needed. I am using my windows machine and probably deserve to encounter minor issues like this.

#2 